### PR TITLE
Enumテーブルを複数テーブルに定義してjoinすると、enumの指定が複数認識できないのを修正する Fixes #21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.uchicom</groupId>
 	<artifactId>iciql</artifactId>
-	<version>2.2.1.6</version>
+	<version>2.2.1.7</version>
 	<name>Iciql</name>
 	<description>a model-based database access wrapper for JDBC</description>
 	<url>http://iciql.com</url>

--- a/src/main/java/com/iciql/Query.java
+++ b/src/main/java/com/iciql/Query.java
@@ -51,6 +51,7 @@ public class Query<T> {
     private int conditionDepth = 0;
     private ArrayList<SelectTable<T>> joins = Utils.newArrayList();
     private final IdentityHashMap<Object, SelectColumn<T>> aliasMap = Utils.newIdentityHashMap();
+    private final HashMap<Class<?>, Integer> enumUsage = new HashMap<>();
     private ArrayList<OrderExpression<T>> orderByList = Utils.newArrayList();
     private ArrayList<Object> groupByExpressions = Utils.newArrayList();
     private long limit;
@@ -72,7 +73,7 @@ public class Query<T> {
         Query<T> query = new Query<T>(db);
         TableDefinition<T> def = (TableDefinition<T>) db.define(alias.getClass());
         query.from = new SelectTable<T>(db, query, alias, false);
-        def.initSelectObject(query.from, alias, query.aliasMap, false);
+        def.initSelectObject(query.from, alias, query.aliasMap, query.enumUsage, false);
         return query;
     }
 
@@ -81,7 +82,7 @@ public class Query<T> {
         Query<T> query = new Query<T>(db);
         TableDefinition<T> def = (TableDefinition<T>) db.define(alias.getClass());
         query.from = new SelectTable<T>(db, query, alias, false);
-        def.initSelectObject(query.from, alias, query.aliasMap, true);
+        def.initSelectObject(query.from, alias, query.aliasMap, query.enumUsage, true);
         return query;
     }
 
@@ -784,6 +785,11 @@ public class Query<T> {
         return this;
     }
 
+    public Query<T> orderByDesc(boolean field) {
+        from.getAliasDefinition().checkMultipleBooleans();
+        return orderByDescPrimitive(field);
+    }
+
     public Query<T> orderByDesc(byte field) {
         return orderByDescPrimitive(field);
     }
@@ -1116,7 +1122,7 @@ public class Query<T> {
     private <A> QueryJoin<T> join(A alias, boolean outerJoin) {
         TableDefinition<T> def = (TableDefinition<T>) db.define(alias.getClass());
         SelectTable<T> join = new SelectTable(db, this, alias, outerJoin);
-        def.initSelectObject(join, alias, aliasMap, false);
+        def.initSelectObject(join, alias, aliasMap, enumUsage, false);
         joins.add(join);
         return new QueryJoin(this, join);
     }

--- a/src/main/java/com/iciql/QueryWhere.java
+++ b/src/main/java/com/iciql/QueryWhere.java
@@ -450,6 +450,11 @@ public class QueryWhere<T> {
         return this;
     }
 
+    private QueryWhere<T> orderByDescPrimitive(Object field) {
+        query.orderByDescPrimitive(field);
+        return this;
+    }
+
     public QueryWhere<T> orderBy(Object field) {
         query.orderBy(field);
         return this;
@@ -477,6 +482,35 @@ public class QueryWhere<T> {
         OrderExpression<T> e = new OrderExpression<T>(query, expr, false, false, true);
         query.addOrderBy(e);
         return this;
+    }
+
+    public QueryWhere<T> orderByDesc(boolean field) {
+        query.getFrom().getAliasDefinition().checkMultipleBooleans();
+        return orderByDescPrimitive(field);
+    }
+
+    public QueryWhere<T> orderByDesc(byte field) {
+        return orderByDescPrimitive(field);
+    }
+
+    public QueryWhere<T> orderByDesc(short field) {
+        return orderByDescPrimitive(field);
+    }
+
+    public QueryWhere<T> orderByDesc(int field) {
+        return orderByDescPrimitive(field);
+    }
+
+    public QueryWhere<T> orderByDesc(long field) {
+        return orderByDescPrimitive(field);
+    }
+
+    public QueryWhere<T> orderByDesc(float field) {
+        return orderByDescPrimitive(field);
+    }
+
+    public QueryWhere<T> orderByDesc(double field) {
+        return orderByDescPrimitive(field);
     }
 
     public QueryWhere<T> orderByDesc(Object expr) {

--- a/src/main/java/com/iciql/TableDefinition.java
+++ b/src/main/java/com/iciql/TableDefinition.java
@@ -1060,8 +1060,7 @@ public class TableDefinition<T> {
         }
     }
 
-    void initSelectObject(SelectTable<T> table, Object obj, Map<Object, SelectColumn<T>> map, boolean reuse) {
-        Map<Class<?>, Integer> enumUsage = new HashMap<>();
+    void initSelectObject(SelectTable<T> table, Object obj, Map<Object, SelectColumn<T>> map, Map<Class<?>, Integer> enumUsage, boolean reuse) {
         for (FieldDefinition def : fields) {
             Object value;
             if (!reuse) {

--- a/src/test/java/com/iciql/test/EnumsTest.java
+++ b/src/test/java/com/iciql/test/EnumsTest.java
@@ -30,6 +30,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -216,6 +217,56 @@ public class EnumsTest {
 
         result = db.from(m).where(m.fromTree).is(Tree.BIRCH).and(m.toTree).is(Tree.WALNUT).selectFirst();
         assertEquals(3, result.id.intValue());
+    }
+
+    @Test
+    public void testEnumJoinSameEnumType() {
+        // Two joined tables share the same Tree enum type.
+        // EnumIdModel (ENUMID encoding: PINE=10) and EnumStringModel (NAME encoding: PINE='PINE').
+        // eim has PINE→id=1, OAK→id=2.
+        // esm has trees reversed: OAK→id=1, PINE→id=2.
+        // Filtering on eim.tree must use eim's column (ENUMID encoding),
+        // not esm's column (NAME encoding). Without the fix, both joined tables
+        // share Tree.PINE as alias, esm overwrites eim in aliasMap, and
+        // filtering on eim.tree would silently use esm's column.
+        Db db2 = IciqlSuite.openNewDb();
+        db2.insertAll(Arrays.asList(
+                new EnumIdModel(1, Tree.PINE, Genus.PINUS),
+                new EnumIdModel(2, Tree.OAK, Genus.QUERCUS)));
+        db2.insertAll(Arrays.asList(
+                new EnumStringModel(1, Tree.OAK, Genus.QUERCUS),
+                new EnumStringModel(2, Tree.PINE, Genus.PINUS)));
+
+        final EnumIdModel eim = new EnumIdModel();
+        final EnumStringModel esm = new EnumStringModel();
+
+        // filter on eim.tree (FROM table, ENUMID encoding) should return id=1
+        List<EnumJoin> result = db2.from(eim)
+                .innerJoin(esm).on(eim.id).is(esm.id)
+                .where(eim.tree()).is(Tree.PINE)
+                .select(new EnumJoin() {{
+                    id = eim.id;
+                    genus = esm.genus();
+                }});
+        assertEquals(1, result.size());
+        assertEquals(1, result.get(0).id.intValue());
+        assertEquals(Genus.QUERCUS, result.get(0).genus);
+
+        // filter on esm.tree (JOIN table, NAME encoding) should return id=2
+        final EnumIdModel eim2 = new EnumIdModel();
+        final EnumStringModel esm2 = new EnumStringModel();
+        List<EnumJoin> result2 = db2.from(eim2)
+                .innerJoin(esm2).on(eim2.id).is(esm2.id)
+                .where(esm2.tree()).is(Tree.PINE)
+                .select(new EnumJoin() {{
+                    id = eim2.id;
+                    genus = esm2.genus();
+                }});
+        assertEquals(1, result2.size());
+        assertEquals(2, result2.get(0).id.intValue());
+        assertEquals(Genus.PINUS, result2.get(0).genus);
+
+        db2.close();
     }
 
     @Test

--- a/src/test/java/com/iciql/test/PrimitivesTest.java
+++ b/src/test/java/com/iciql/test/PrimitivesTest.java
@@ -117,6 +117,27 @@ public class PrimitivesTest {
     }
 
     @Test
+    public void testOrderByDescBoolean() {
+        Db db = IciqlSuite.openNewDb();
+
+        List<PrimitivesModel> models = PrimitivesModel.getList();
+        db.insertAll(models);
+
+        PrimitivesModel p = new PrimitivesModel();
+
+        // verify orderByDesc(boolean) works as a column reference, not a literal
+        List<PrimitivesModel> list = db.from(p).orderByDesc(p.myBoolean).select();
+        assertEquals(models.size(), list.size());
+
+        // verify QueryWhere orderByDesc with primitive works
+        List<PrimitivesModel> filtered = db.from(p).where(p.myLong).exceeds(5L).orderByDesc(p.myLong).select();
+        assertEquals(5, filtered.size());
+        assertEquals("[10, 9, 8, 7, 6]", filtered.toString());
+
+        db.close();
+    }
+
+    @Test
     public void testPrimitiveGroupByCount() {
         Db db = IciqlSuite.openNewDb();
 


### PR DESCRIPTION
- Fixes #21